### PR TITLE
Install expo react-native-gesture-handler to remove UIManager errorr

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5653,11 +5653,6 @@
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
     },
-    "hammerjs": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
-      "integrity": "sha1-BO93hiz/K7edMPdpIJWTAiK/YPE="
-    },
     "handlebars": {
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.5.tgz",
@@ -10168,14 +10163,13 @@
       }
     },
     "react-native-gesture-handler": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-1.4.1.tgz",
-      "integrity": "sha512-Ffcs+SbEbkGaal0CClYL+v7A9y4OA5G5lW01qrzjxaqASp5C8BfnWSKuqYKE00s6bLwE5L4xnlHkG0yIxAtbrQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-1.3.0.tgz",
+      "integrity": "sha512-ASRFIXBuKRvqlmwkWJhV8yP2dTpvcqVrLNpd7FKVBFHYWr6SAxjGyO9Ik8w1lAxDhMlRP2IcJ9p9eq5X2WWeLQ==",
       "requires": {
-        "hammerjs": "^2.0.8",
         "hoist-non-react-statics": "^2.3.1",
-        "invariant": "^2.2.4",
-        "prop-types": "^15.7.2"
+        "invariant": "^2.2.2",
+        "prop-types": "^15.5.10"
       },
       "dependencies": {
         "hoist-non-react-statics": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "react-native": "https://github.com/expo/react-native/archive/sdk-35.0.0.tar.gz",
     "react-native-datepicker": "^1.7.2",
     "react-native-geolocation-service": "^3.1.0",
-    "react-native-gesture-handler": "^1.3.1",
+    "react-native-gesture-handler": "~1.3.0",
     "react-native-maps": "~0.25.0",
     "react-native-web": "^0.11.7",
     "react-navigation": "^4.0.10",


### PR DESCRIPTION
- [ ] Wrote Tests
- [x] Implemented
- [ ] Reviewed

### Necessary checkmarks:
- [x] All Tests are Passing
- [x] The code will run locally

### Type of change
- [ ] New feature
- [x] Bug Fix

### Implements/Fixes:

install react-native-gesture-handler to remove UImanager error on app load

### Description of Changes:


[closes#109](https://github.com/lundgrea/FE-Trex/projects/2#card-28351779)

### Check the correct boxes
- [x] This broke nothing
- [ ] This broke some stuff
- [ ] This broke everything

### Testing Changes
- COVERAGE SCORE:
- [ ] New Tests have been added
- [x] No Tests have been changed
- [ ] Some Tests have been changed
- [ ] All of the Tests have been changed (Please describe what in the world happened)

### Checklist:
- [x] My code has no unused/commented out code
- [x] I have reviewed my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have fully tested my code

